### PR TITLE
Include git as a dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 RUN apt-get update
-RUN apt-get -yy install build-essential ruby-dev
+RUN apt-get -yy install build-essential ruby-dev git
 
 RUN gem install bundler
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ None
 
 * `build-essential`
 * `ruby-dev`
+* `git`
 
 ### Ruby Environment
 


### PR DESCRIPTION
Git is needed for Gemfiles that use git based gem sources, e.g. `gem
'stripe', git: 'https://github.com/stripe/stripe-ruby'`.